### PR TITLE
Fix portnumber for TypeSafeClient example

### DIFF
--- a/ch11/src/test/java/com/packt/microprofile/ch11/client/TypeSafeClientIT.java
+++ b/ch11/src/test/java/com/packt/microprofile/ch11/client/TypeSafeClientIT.java
@@ -54,7 +54,7 @@ public class TypeSafeClientIT {
     public void testAllProfiles() throws Exception {
         //System.out.println("classpath: " + System.getProperty("java.class.path"));
         ProfileApi api = TypesafeGraphQLClientBuilder.newBuilder()
-                                                     .endpoint("http://localhost:9079/graphql")
+                                                     .endpoint("http://localhost:9080/graphql")
                                                      .build(ProfileApi.class);
         List<OwnerProfile> allProfiles = api.allProfiles();
         assertNotNull(allProfiles);


### PR DESCRIPTION
Don't know if it is intentional, or there is some other reason for using different ports for the dynamic and typesafe example. But it may be confusing for the reader of the book.
